### PR TITLE
add workloadIdentitySettings ConfigMap for access to GKE fields

### DIFF
--- a/apis/composition.yaml
+++ b/apis/composition.yaml
@@ -335,7 +335,7 @@ spec:
                 toFieldPath: metadata.name
                 transforms:
                   - string:
-                      fmt: '%s-worload-identity-settings'
+                      fmt: '%s-workload-identity-settings'
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
@@ -343,7 +343,7 @@ spec:
                 toFieldPath: spec.forProvider.manifest.metadata.name
                 transforms:
                   - string:
-                      fmt: '%s-worload-identity-settings'
+                      fmt: '%s-workload-identity-settings'
                       type: Format
                     type: string
                 type: FromCompositeFieldPath

--- a/apis/composition.yaml
+++ b/apis/composition.yaml
@@ -311,3 +311,39 @@ spec:
                       type: Format
             readinessChecks:
               - type: None
+
+          - name: workloadIdentitySettings
+            base:
+              apiVersion: kubernetes.crossplane.io/v1alpha2
+              kind: Object
+              spec:
+                deletionPolicy: Orphan
+                forProvider:
+                  manifest:
+                    apiVersion: v1
+                    kind: ConfigMap
+                    metadata:
+                      namespace: default
+            patches:
+              - fromFieldPath: spec.parameters.id
+                toFieldPath: spec.providerConfigRef.name
+                type: FromCompositeFieldPath
+              - fromFieldPath: spec.parameters.id
+                toFieldPath: metadata.name
+                transforms:
+                  - string:
+                      fmt: '%s-worload-identity-settings'
+                      type: Format
+                    type: string
+                type: FromCompositeFieldPath
+              - fromFieldPath: spec.parameters.id
+                toFieldPath: spec.forProvider.manifest.metadata.name
+                transforms:
+                  - string:
+                      fmt: '%s-worload-identity-settings'
+                      type: Format
+                    type: string
+                type: FromCompositeFieldPath
+              - fromFieldPath: spec.forProvider.project
+                toFieldPath: spec.forProvider.manifest.data.gkeProject
+                type: FromCompositeFieldPath

--- a/apis/composition.yaml
+++ b/apis/composition.yaml
@@ -172,6 +172,9 @@ spec:
               - type: FromCompositeFieldPath
                 fromFieldPath: spec.parameters.version
                 toFieldPath: spec.forProvider.minMasterVersion
+              - fromFieldPath: status.atProvider.project
+                toFieldPath: status.gke.project
+                type: ToCompositeFieldPath
 
           - name: node-pool
             base:
@@ -344,6 +347,6 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: spec.forProvider.project
+              - fromFieldPath: status.gke.project
                 toFieldPath: spec.forProvider.manifest.data.gkeProject
                 type: FromCompositeFieldPath


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

In order to add external-dns support to `platform-ref-upbound-spaces` for GKE, we need access to some fields via ConfigMap:

- GKE Project


Fixes #

I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

In the output of the E2E I saw this:

```
   apiVersion: v1
   items:
   - apiVersion: kubernetes.crossplane.io/v1alpha2
     kind: Object
     metadata:
       annotations:
         crossplane.io/composition-resource-name: workloadIdentitySettings
         crossplane.io/external-create-pending: "2024-05-27T18:18:46Z"
         crossplane.io/external-create-succeeded: "2024-05-27T18:18:46Z"
         crossplane.io/external-name: configuration-gcp-gke-workload-identity-settings
         upjet.upbound.io/test: "true"
       creationTimestamp: "2024-05-27T18:11:20Z"
       finalizers:
       - finalizer.managedresource.crossplane.io
       generateName: configuration-gcp-gke-
       generation: 3
       labels:
         crossplane.io/claim-name: ""
         crossplane.io/claim-namespace: ""
         crossplane.io/composite: configuration-gcp-gke
       name: configuration-gcp-gke-workload-identity-settings
       ownerReferences:
       - apiVersion: gcp.platform.upbound.io/v1alpha1
         blockOwnerDeletion: true
         controller: true
         kind: XGKE
         name: configuration-gcp-gke
         uid: 8942a8a4-afe1-4c4a-acd9-bd8fd0fc9dbe
       resourceVersion: "3056"
       uid: b5967619-e1f6-4dca-8c8a-62dd9dc63c84
     spec:
       deletionPolicy: Orphan
       forProvider:
         manifest:
           apiVersion: v1
           data:
             gkeProject: official-provider-testing
           kind: ConfigMap
           metadata:
             name: configuration-gcp-gke-workload-identity-settings
             namespace: default
       managementPolicies:
       - '*'
       providerConfigRef:
         name: configuration-gcp-gke
       readiness:
         policy: SuccessfulCreate
     status:
       atProvider:
         manifest:
           apiVersion: v1
           data:
             gkeProject: official-provider-testing
           kind: ConfigMap
           metadata:
             annotations:
               kubectl.kubernetes.io/last-applied-configuration: '***"apiVersion":"v1","data":***"gkeProject":"official-provider-testing"***,"kind":"ConfigMap","metadata":***"name":"configuration-gcp-gke-workload-identity-settings","namespace":"default"***'
             creationTimestamp: "2024-05-27T18:18:46Z"
             managedFields:
             - apiVersion: v1
               fieldsType: FieldsV1
               fieldsV1:
                 f:data:
                   .: ***
                   f:gkeProject: ***
                 f:metadata:
                   f:annotations:
                     .: ***
                     f:kubectl.kubernetes.io/last-applied-configuration: ***
               manager: crossplane-kubernetes-provider
               operation: Update
               time: "2024-05-27T18:18:46Z"
             name: configuration-gcp-gke-workload-identity-settings
             namespace: default
             resourceVersion: "2115"
             uid: 50e8a17f-852e-4f68-bbbb-9f72ed22eb95
       conditions:
       - lastTransitionTime: "2024-05-27T18:18:46Z"
         reason: ReconcileSuccess
         status: "True"
         type: Synced
       - lastTransitionTime: "2024-05-27T18:18:46Z"
         reason: Available
         status: "True"
         type: Ready
```