### PR TITLE
Stabilize provider-{helm,kubernetes} dependencies to v0

### DIFF
--- a/upbound.yaml
+++ b/upbound.yaml
@@ -23,11 +23,11 @@ spec:
   - apiVersion: pkg.crossplane.io/v1
     kind: Provider
     package: xpkg.upbound.io/upbound/provider-helm
-    version: '>=v0.0.0'
+    version: v0
   - apiVersion: pkg.crossplane.io/v1
     kind: Provider
     package: xpkg.upbound.io/upbound/provider-kubernetes
-    version: '>=v0.0.0'
+    version: v0
   - apiVersion: pkg.crossplane.io/v1
     kind: Configuration
     package: xpkg.upbound.io/upbound/configuration-gcp-network


### PR DESCRIPTION
### Description of your changes

To avoid conflicts in the higher level abstractions like platform-ref-gcp

Before this change the lock file in platform-ref-gcp:
```
  - lastTransitionTime: "2025-09-30T16:50:49Z"
    message: 'Error occurred during dependency resolution cannot find dependency version
      to upgrade: dependency (xpkg.upbound.io/upbound/provider-helm) does not have
      a valid version to upgrade that satisfies all constraints. If there is a valid
      version that requires downgrade, manual intervention is required. Constraints:
      [>=v0.0.0 v0 v0 v0]'
```

After the switch to explicit v0, the problem goes away

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->



<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

e2e test with platform-ref-gcp
