### PR TITLE
fix: relax provider version constraints to v2 channel

### DIFF
--- a/upbound.yaml
+++ b/upbound.yaml
@@ -11,15 +11,15 @@ spec:
   - apiVersion: pkg.crossplane.io/v1
     kind: Provider
     package: xpkg.upbound.io/upbound/provider-gcp-compute
-    version: v2.4.0
+    version: v2
   - apiVersion: pkg.crossplane.io/v1
     kind: Provider
     package: xpkg.upbound.io/upbound/provider-gcp-container
-    version: v2.4.0
+    version: v2
   - apiVersion: pkg.crossplane.io/v1
     kind: Provider
     package: xpkg.upbound.io/upbound/provider-gcp-cloudplatform
-    version: v2.4.0
+    version: v2
   - apiVersion: pkg.crossplane.io/v1
     kind: Provider
     package: xpkg.upbound.io/upbound/provider-helm


### PR DESCRIPTION
## Summary

- Change `provider-gcp-compute`, `provider-gcp-container`, and `provider-gcp-cloudplatform` version constraints from `v2.4.0` (exact) to `v2` (channel)

## Problem

When `configuration-gcp-gke` and `configuration-gcp-network` are installed together, Crossplane's dependency resolver fails with:

```
cannot find dependency version to upgrade: dependency (xpkg.upbound.io/upbound/provider-gcp-compute)
does not have a valid version to upgrade that satisfies all constraints.
Constraints: [v2 v2.4.0]
```

`configuration-gcp-network` declares `provider-gcp-compute: v2` (resolves to latest v2.x, e.g. v2.5.3), while this configuration pinned `v2.4.0` exactly. The resolver cannot satisfy both simultaneously.

## Fix

Use `v2` channel constraint (consistent with `configuration-gcp-network`) to allow the resolver to pick the latest v2.x version satisfying all consumers.