### PR TITLE
fix: relax provider-helm and provider-kubernetes constraints to v1 channel

### DIFF
--- a/upbound.yaml
+++ b/upbound.yaml
@@ -23,11 +23,11 @@ spec:
   - apiVersion: pkg.crossplane.io/v1
     kind: Provider
     package: xpkg.upbound.io/upbound/provider-helm
-    version: v1.0.0
+    version: v1
   - apiVersion: pkg.crossplane.io/v1
     kind: Provider
     package: xpkg.upbound.io/upbound/provider-kubernetes
-    version: v1.0.0
+    version: v1
   - apiVersion: pkg.crossplane.io/v1
     kind: Configuration
     package: xpkg.upbound.io/upbound/configuration-gcp-network


### PR DESCRIPTION
## Summary

- Change `provider-helm` and `provider-kubernetes` version constraints from `v1.0.0` (exact) to `v1` (channel)

## Problem

Exact `v1.0.0` pins conflicted with `v1` channel constraints declared by `configuration-app` and `configuration-observability-oss`. This caused the Crossplane package manager to create duplicate `ProviderRevision` objects — one per distinct constraint — and the new active revision couldn't take ownership of CRDs already held by the older inactive revision, leaving `provider-kubernetes` permanently unhealthy with:

```
cannot establish control of object: providerconfigusages.kubernetes.m.crossplane.io
is already controlled by ProviderRevision upbound-provider-kubernetes-631359f5cb71
```

## Fix

Use `v1` channel constraint (consistent with other upstream configurations) so all packages agree on a single resolved version.