### PR TITLE
feat: extended status params for a reuse

### DIFF
--- a/apis/gke/definition.yaml
+++ b/apis/gke/definition.yaml
@@ -26,6 +26,9 @@ spec:
                     id:
                       type: string
                       description: ID of this Cluster that other objects will use to refer to it.
+                    project:
+                      type: string
+                      description: GCP project ID for the GKE cluster and service account, and used to derive the Workload Identity pool.
                     region:
                       type: string
                       description: Region is the region you'd like your resource to be created in.
@@ -49,7 +52,23 @@ spec:
                     version:
                       description: Kubernetes version
                       type: string
-                      default: latest
+                      enum:
+                        - latest
+                        - "1.35"
+                        - "1.34"
+                        - "1.33"
+                        - "1.32"
+                      default: "1.34"
+                    workloadIdentity:
+                      type: object
+                      description: Workload Identity configuration parameters.
+                      properties:
+                        enabled:
+                          type: boolean
+                          description: Enable Workload Identity on the cluster and node pool.
+                          default: true
+                      default:
+                        enabled: true
                     nodes:
                       type: object
                       description: GKE node configuration parameters.
@@ -57,15 +76,16 @@ spec:
                         count:
                           type: integer
                           description: Desired node count, from 1 to 100.
-                        instanceType:
+                        machineType:
                           type: string
-                          description: instance types associated with the Node Group.
-                          default: n1-standard-4
+                          description: Machine type associated with the node pool.
+                          default: e2-standard-2
                       required:
                         - count
-                        - instanceType
+                        - machineType
                   required:
                     - id
+                    - project
                     - region
                     - managementPolicies
                     - providerConfigName

--- a/apis/gke/definition.yaml
+++ b/apis/gke/definition.yaml
@@ -76,16 +76,15 @@ spec:
                         count:
                           type: integer
                           description: Desired node count, from 1 to 100.
-                        machineType:
+                        instanceType:
                           type: string
-                          description: Machine type associated with the node pool.
-                          default: e2-standard-2
+                          description: instance types associated with the Node Group.
+                          default: n1-standard-4
                       required:
                         - count
-                        - machineType
+                        - instanceType
                   required:
                     - id
-                    - project
                     - region
                     - managementPolicies
                     - providerConfigName

--- a/examples/gke-xr.yaml
+++ b/examples/gke-xr.yaml
@@ -6,8 +6,9 @@ metadata:
 spec:
   parameters:
     id: configuration-gcp-gke
+    project: test-project-123
     region: us-west2
-    version: latest
+    version: "1.34"
     nodes:
       count: 1
-      instanceType: n1-standard-4
+      machineType: e2-standard-2

--- a/examples/gke-xr.yaml
+++ b/examples/gke-xr.yaml
@@ -11,4 +11,4 @@ spec:
     version: "1.34"
     nodes:
       count: 1
-      machineType: e2-standard-2
+      instanceType: e2-standard-2

--- a/functions/gke/main.k
+++ b/functions/gke/main.k
@@ -1,16 +1,17 @@
 
 import models.io.upbound.gcpm.cloudplatform.v1beta1 as cloudplatformv1beta1
 import models.io.upbound.gcpm.container.v1beta1 as containerv1beta1
-import models.io.upbound.platform.gcp.v1alpha1 as platformgcpv1alpha1
 import models.io.crossplane.helmm.v1beta1 as helmv1beta1
 import models.io.crossplane.kubernetesm.v1alpha1 as kubernetesv1alpha1
 import models.io.k8s.api.core.v1 as corev1
 import base64
 
-oxr = platformgcpv1alpha1.GKE{**option("params").oxr}
+oxr = option("params").oxr # observed composite resource
 _ocds = option("params")?.ocds or {}
+_dxr = option("params").dxr # desired composite resource
 params = oxr.spec.parameters
 providerConfigRefName = params.providerConfigName or "default"
+_workloadIdentityEnabled = params?.workloadIdentity?.enabled if params?.workloadIdentity?.enabled != Undefined else True
 
 # Get status information from observed composed resources using correct access pattern
 _service_account_id = _ocds?.serviceaccount?.Resource?.status?.atProvider?.id or ""
@@ -21,18 +22,21 @@ _cluster_project_id = _ocds?.gkecluster?.Resource?.status?.atProvider?.project o
 _serviceAccountReadyCondition = [condition for condition in (_ocds?.serviceaccount?.Resource?.status?.conditions or []) if condition.type == "Ready" and condition.status == "True"]
 _isServiceAccountReady = len(_serviceAccountReadyCondition) > 0
 
-# Extract project ID from service account status
-_project_id = ""
+# Extract project ID from service account status (used as a fallback)
+_derived_project_id = ""
 if _service_account_id:
     # Format: "projects/test-project-123/serviceAccounts/email"
     # Split by "/" and take the element at index 1
     parts = _service_account_id.split("/")
     if len(parts) >= 2 and parts[0] == "projects":
-        _project_id = parts[1]
+        _derived_project_id = parts[1]
 
 # Get project ID from GKE cluster status (fallback)
-if not _project_id and _cluster_project_id:
-    _project_id = _cluster_project_id
+if not _derived_project_id and _cluster_project_id:
+    _derived_project_id = _cluster_project_id
+
+# Prefer the explicit params.project; fall back to the runtime-derived project id.
+_project_id = params.project or _derived_project_id
 
 _metadata = lambda name: str -> any {
     {
@@ -50,8 +54,7 @@ _defaults = {
 }
 
 _connection_secret_name = lambda suffix: str -> str {
-    _uid = oxr.metadata.uid if oxr.metadata?.uid else oxr.metadata.name
-    "{}-{}".format(_uid, suffix)
+    "{}-{}".format(params.id, suffix)
 }
 
 # Create service account and IAM resources first
@@ -130,9 +133,9 @@ _gke_items = [] if not (_service_account_email and _isServiceAccountReady) else 
                 nodeConfig = {
                     serviceAccount = _service_account_email
                 }
-                workloadIdentityConfig = {
+                **({workloadIdentityConfig = {
                     workloadPool = "{}.svc.id.goog".format(_project_id)
-                }
+                }} if _workloadIdentityEnabled else {})
             }
             writeConnectionSecretToRef = {
                 name = _connection_secret_name("gkecluster")
@@ -160,7 +163,7 @@ _gke_items = [] if not (_service_account_email and _isServiceAccountReady) else 
                 nodeConfig = {
                     diskSizeGb = 10
                     imageType = "COS_CONTAINERD"
-                    machineType = params.nodes.instanceType
+                    machineType = params.nodes.machineType
                     metadata = {
                         "disable-legacy-endpoints" = "true"
                     }
@@ -173,6 +176,9 @@ _gke_items = [] if not (_service_account_email and _isServiceAccountReady) else 
                         enableSecureBoot = True
                     }
                     serviceAccount = _service_account_email
+                    **({workloadMetadataConfig = {
+                        mode = "GKE_METADATA"
+                    }} if _workloadIdentityEnabled else {})
                 }
             }
         }
@@ -283,4 +289,45 @@ _gke_items = [] if not (_service_account_email and _isServiceAccountReady) else 
     }
 ]
 
-items = _base_items + _gke_items
+# Read the observed NodePool nodeConfig. upjet serializes nodeConfig as either a
+# single object or a single-element list depending on the provider version, so
+# handle both shapes; fall back to the desired machineType when unset.
+_nodepool_node_config = _ocds?["node-pool"]?.Resource?.status?.atProvider?.nodeConfig
+_nodepool_node_config_obj = (_nodepool_node_config[0] if len(_nodepool_node_config) > 0 else {}) if typeof(_nodepool_node_config) == "list" else (_nodepool_node_config or {})
+_nodepool_machine_type = _nodepool_node_config_obj?.machineType or params.nodes.machineType
+
+# Observed cluster metadata name, falling back to the params.id external name.
+_observed_cluster_name = _ocds?.gkecluster?.Resource?.metadata?.name or params.id
+
+# Surface typed status into the freeform status.gke so higher-level
+# configurations (e.g. configuration-gcp-ctp) can compose a GKE XR and read the
+# resolved project, workload pool, kubeconfig secret and running machine type
+# instead of composing their own observe-only managed resources. Emit a minimal
+# status patch on the composite (apiVersion/kind/metadata carry identity; the
+# rest of the spec is left untouched so function-auto-ready still aggregates
+# composed-resource readiness).
+_status_patch = {
+    apiVersion: _dxr.apiVersion
+    kind: _dxr.kind
+    metadata: {
+        name: oxr.metadata.name
+        namespace: oxr.metadata.namespace
+    }
+    status: {
+        gke: {
+            clusterName: _observed_cluster_name
+            project: _project_id
+            workloadPool: "{}.svc.id.goog".format(_project_id)
+            kubeconfigSecretRef: {
+                name: "{}-connection".format(oxr.metadata.name)
+                namespace: oxr.metadata.namespace
+                key: "kubeconfig"
+            }
+            nodePool: {
+                machineType: _nodepool_machine_type
+            }
+        }
+    }
+}
+
+items = _base_items + _gke_items + [_status_patch]

--- a/functions/gke/main.k
+++ b/functions/gke/main.k
@@ -163,7 +163,7 @@ _gke_items = [] if not (_service_account_email and _isServiceAccountReady) else 
                 nodeConfig = {
                     diskSizeGb = 10
                     imageType = "COS_CONTAINERD"
-                    machineType = params.nodes.machineType
+                    machineType = params.nodes.instanceType
                     metadata = {
                         "disable-legacy-endpoints" = "true"
                     }
@@ -294,7 +294,7 @@ _gke_items = [] if not (_service_account_email and _isServiceAccountReady) else 
 # handle both shapes; fall back to the desired machineType when unset.
 _nodepool_node_config = _ocds?["node-pool"]?.Resource?.status?.atProvider?.nodeConfig
 _nodepool_node_config_obj = (_nodepool_node_config[0] if len(_nodepool_node_config) > 0 else {}) if typeof(_nodepool_node_config) == "list" else (_nodepool_node_config or {})
-_nodepool_machine_type = _nodepool_node_config_obj?.machineType or params.nodes.machineType
+_nodepool_machine_type = _nodepool_node_config_obj?.machineType or params.nodes.instanceType
 
 # Observed cluster metadata name, falling back to the params.id external name.
 _observed_cluster_name = _ocds?.gkecluster?.Resource?.metadata?.name or params.id
@@ -324,7 +324,7 @@ _status_patch = {
                 key: "kubeconfig"
             }
             nodePool: {
-                machineType: _nodepool_machine_type
+                instanceType: _nodepool_machine_type
             }
         }
     }

--- a/tests/e2etest-gke/main.k
+++ b/tests/e2etest-gke/main.k
@@ -33,7 +33,7 @@ _gke_xr = platformgcpv1alpha1.GKE{
             version = "1.34"
             nodes = {
                 count = 1
-                machineType = "e2-medium"
+                instanceType = "e2-medium"
             }
             managementPolicies = ["*"]
             providerConfigName = "default"

--- a/tests/e2etest-gke/main.k
+++ b/tests/e2etest-gke/main.k
@@ -28,11 +28,12 @@ _gke_xr = platformgcpv1alpha1.GKE{
     spec = {
         parameters = {
             id = "e2e-gke-cluster"
+            project = "crossplane-playground"
             region = "us-west2"
-            version = "latest"
+            version = "1.34"
             nodes = {
                 count = 1
-                instanceType = "e2-medium"
+                machineType = "e2-medium"
             }
             managementPolicies = ["*"]
             providerConfigName = "default"

--- a/tests/test-gke/main.k
+++ b/tests/test-gke/main.k
@@ -20,14 +20,30 @@ _items = [
                     spec = {
                         parameters = {
                             id = "configuration-gcp-gke"
+                            project = "test-project-123"
                             region = "us-west2"
-                            version = "latest"
+                            version = "1.34"
                             nodes = {
                                 count = 1
-                                instanceType = "n1-standard-4"
+                                machineType = "e2-standard-2"
                             }
                             managementPolicies = ["*"]
                             providerConfigName = "default"
+                        }
+                    }
+                    status = {
+                        gke = {
+                            clusterName = "configuration-gcp-gke"
+                            project = "test-project-123"
+                            workloadPool = "test-project-123.svc.id.goog"
+                            kubeconfigSecretRef = {
+                                name = "configuration-gcp-gke-connection"
+                                namespace = "default"
+                                key = "kubeconfig"
+                            }
+                            nodePool = {
+                                machineType = "n2-standard-4"
+                            }
                         }
                     }
                 }
@@ -124,6 +140,8 @@ _items = [
                                     "networks.gcp.platform.upbound.io/network-id" = "configuration-gcp-gke"
                                 }
                             }
+                            nodeVersion = "1.34"
+                            minMasterVersion = "1.34"
                             nodeConfig = {
                                 serviceAccount = "test-sa@test-project-123.iam.gserviceaccount.com"
                             }
@@ -166,7 +184,7 @@ _items = [
                             nodeConfig = {
                                 diskSizeGb = 10
                                 imageType = "COS_CONTAINERD"
-                                machineType = "n1-standard-4"
+                                machineType = "e2-standard-2"
                                 metadata = {
                                     "disable-legacy-endpoints" = "true"
                                 }
@@ -179,6 +197,9 @@ _items = [
                                     enableSecureBoot = True
                                 }
                                 serviceAccount = "test-sa@test-project-123.iam.gserviceaccount.com"
+                                workloadMetadataConfig = {
+                                    mode = "GKE_METADATA"
+                                }
                             }
                         }
                         providerConfigRef = {
@@ -299,8 +320,12 @@ _items = [
             validate: False
             observedResources: [
                 cloudplatformv1beta1.ServiceAccount{
-                    metadata.annotations = {
-                        "crossplane.io/composition-resource-name": "serviceaccount"
+                    metadata = {
+                        name: "configuration-gcp-gke"
+                        namespace: "default"
+                        annotations = {
+                            "crossplane.io/composition-resource-name": "serviceaccount"
+                        }
                     }
                     spec = {
                         forProvider = {
@@ -327,8 +352,12 @@ _items = [
                     }
                 }
                 containerv1beta1.Cluster{
-                    metadata.annotations = {
-                        "crossplane.io/composition-resource-name": "gkecluster"
+                    metadata = {
+                        name: "configuration-gcp-gke"
+                        namespace: "default"
+                        annotations = {
+                            "crossplane.io/composition-resource-name": "gkecluster"
+                        }
                     }
                     spec = {
                         forProvider = {
@@ -342,6 +371,31 @@ _items = [
                     status = {
                         atProvider = {
                             project: "test-project-123"
+                        }
+                    }
+                }
+                containerv1beta1.NodePool{
+                    metadata = {
+                        name: "configuration-gcp-gke"
+                        namespace: "default"
+                        annotations = {
+                            "crossplane.io/composition-resource-name": "node-pool"
+                        }
+                    }
+                    spec = {
+                        forProvider = {
+                            location: "us-west2"
+                        }
+                        providerConfigRef = {
+                            kind = "ProviderConfig"
+                            name: "default"
+                        }
+                    }
+                    status = {
+                        atProvider = {
+                            nodeConfig = {
+                                machineType: "n2-standard-4"
+                            }
                         }
                     }
                 }

--- a/tests/test-gke/main.k
+++ b/tests/test-gke/main.k
@@ -25,7 +25,7 @@ _items = [
                             version = "1.34"
                             nodes = {
                                 count = 1
-                                machineType = "e2-standard-2"
+                                instanceType = "e2-standard-2"
                             }
                             managementPolicies = ["*"]
                             providerConfigName = "default"
@@ -42,7 +42,7 @@ _items = [
                                 key = "kubeconfig"
                             }
                             nodePool = {
-                                machineType = "n2-standard-4"
+                                instanceType = "n2-standard-4"
                             }
                         }
                     }


### PR DESCRIPTION
### Description of your changes

Extends the `GKE` XR so a higher-level configuration (`configuration-gcp-ctp`) can compose it - instead of inlining raw GCP managed resources - the way `configuration-aws-ctp` composes an `EKS` XR. 
Adds the parameters it needs and surfaces cluster metadata on `status.gke`. All changes are additive and backward-compatible except the two noted below:

- Connection-secret naming changed from `uid`-based to `params.id`-based. 
The old uid-based name was non-deterministic (and broke tests under up v0.50.0). Stable name is required for a reusable `kubeconfigSecretRef`. This changes the kubeconfig secret's name at runtime.

- No provider-config change - the XR stays on namespaced `ProviderConfig` (same as aws-eks/azure-aks); no network change (relies on the ProviderConfig's default project).