### PR TITLE
fix: pin GCP family providers to v1 channel (v0.11.2)

### DIFF
--- a/upbound.yaml
+++ b/upbound.yaml
@@ -11,15 +11,15 @@ spec:
   - apiVersion: pkg.crossplane.io/v1
     kind: Provider
     package: xpkg.upbound.io/upbound/provider-gcp-compute
-    version: '>=v0.0.0'
+    version: v1
   - apiVersion: pkg.crossplane.io/v1
     kind: Provider
     package: xpkg.upbound.io/upbound/provider-gcp-container
-    version: '>=v0.0.0'
+    version: v1
   - apiVersion: pkg.crossplane.io/v1
     kind: Provider
     package: xpkg.upbound.io/upbound/provider-gcp-cloudplatform
-    version: '>=v0.0.0'
+    version: v1
   - apiVersion: pkg.crossplane.io/v1
     kind: Provider
     package: xpkg.upbound.io/upbound/provider-helm


### PR DESCRIPTION
## Problem

`XGKE` fails to provision on the v0.11.x line. The NodePool is rejected by the provider conversion webhook:

```
cannot apply composed resource "node-pool": ... conversion webhook for
container.gcp.upbound.io/v1beta1, Kind=NodePool failed: cannot convert from the
spoke version "v1beta1" to the hub version "v1beta2": ... singleton list, at the
field path nodeConfig, must have a length of at most 1 but it has a length of 2
```

## Root cause

The DevEx migration (v0.11.0) left the GCP providers on an **unpinned `>=v0.0.0`** constraint. That now resolves to **provider-family-gcp v2.6.0**, whose container `NodePool` storage/hub version is `v1beta2` with a strict singleton-list conversion. The KCL composition (`functions/xgke/main.k`) creates the NodePool at **`v1beta1`**, so the `v1beta1 → v1beta2` server-side-apply merge doubles the `nodeConfig` singleton list to 2 elements and the conversion is rejected. The node pool is never created.

## Evidence

- **v0.10.0** pins these providers to `"v1"` and provisions GKE cleanly (`NodePool ... True True Available`).
- **v0.11.1** (unpinned) pulls provider-family-gcp **v2.6.0** and fails deterministically with the error above — reproduced in downstream `configuration-gcp-gke-workload-identity` PR #33 e2e, on repeated runs, with the same Crossplane version.

## Fix

Pin `provider-gcp-compute`, `provider-gcp-container`, and `provider-gcp-cloudplatform` to the **`v1`** channel — restoring the v0.10.0 behaviour. The three must move together since they share `provider-family-gcp`. `provider-helm`/`provider-kubernetes` stay on `v0`; `function-auto-ready` is unchanged.

## Release / branch plan

- Per-patch branch `release-0.11.2` was cut from `release-0.11` at this same commit (matching the `release-2.0.3` precedent); **`v0.11.2` will be tagged from `release-0.11.2`**.
- This PR merges the fix **back into `release-0.11`** so the maintenance branch is not left broken.

## Validation

- [ ] composition-tests green
- [ ] e2e green — confirm `NodePool ... True True Available` (trigger via the usual label/comment)

Only tag `v0.11.2` once e2e is green.