### PR TITLE
fix: pin GCP family providers to v1 and use params.id for con sec names

### DIFF
--- a/functions/xgke/main.k
+++ b/functions/xgke/main.k
@@ -47,8 +47,7 @@ _defaults = {
 }
 
 _connection_secret_name = lambda suffix: str -> str {
-    _uid = oxr.metadata.uid if oxr.metadata?.uid else oxr.metadata.name
-    "{}-{}".format(_uid, suffix)
+    "{}-{}".format(params.id, suffix)
 }
 
 # Create service account and IAM resources first

--- a/tests/test-xgke/main.k
+++ b/tests/test-xgke/main.k
@@ -278,8 +278,12 @@ _items = [
             validate: False
             observedResources: [
                 cloudplatformv1beta1.ServiceAccount{
-                    metadata.annotations = {
-                        "crossplane.io/composition-resource-name": "serviceaccount"
+                    metadata = {
+                        name: "configuration-gcp-gke"
+                        namespace: "default"
+                        annotations = {
+                            "crossplane.io/composition-resource-name": "serviceaccount"
+                        }
                     }
                     spec = {
                         forProvider = {

--- a/upbound.yaml
+++ b/upbound.yaml
@@ -11,15 +11,15 @@ spec:
   - apiVersion: pkg.crossplane.io/v1
     kind: Provider
     package: xpkg.upbound.io/upbound/provider-gcp-compute
-    version: '>=v0.0.0'
+    version: v1
   - apiVersion: pkg.crossplane.io/v1
     kind: Provider
     package: xpkg.upbound.io/upbound/provider-gcp-container
-    version: '>=v0.0.0'
+    version: v1
   - apiVersion: pkg.crossplane.io/v1
     kind: Provider
     package: xpkg.upbound.io/upbound/provider-gcp-cloudplatform
-    version: '>=v0.0.0'
+    version: v1
   - apiVersion: pkg.crossplane.io/v1
     kind: Provider
     package: xpkg.upbound.io/upbound/provider-helm
@@ -31,7 +31,7 @@ spec:
   - apiVersion: pkg.crossplane.io/v1
     kind: Configuration
     package: xpkg.upbound.io/upbound/configuration-gcp-network
-    version: v0.9.0
+    version: v0.9.1
   - apiVersion: pkg.crossplane.io/v1
     kind: Function
     package: xpkg.upbound.io/crossplane-contrib/function-auto-ready


### PR DESCRIPTION
### Issue

`XGKE` fails to provision on the v0.11.x line. The NodePool is rejected by the provider conversion webhook:

cannot apply composed resource "node-pool": ... conversion webhook for
container.gcp.upbound.io/v1beta1, Kind=NodePool failed: cannot convert from the
spoke version "v1beta1" to the hub version "v1beta2": ... singleton list, at the
field path nodeConfig, must have a length of at most 1 but it has a length of 2

it blocks merge of: https://github.com/upbound/configuration-gcp-gke-workload-identity/pull/33 

### Root cause

The DevEx migration (v0.11.0) left the GCP providers on an unpinned >=v0.0.0 constraint. That now resolves to provider-family-gcp v2.6.0, whose container NodePool storage/hub version is v1beta2 with a strict singleton-list conversion. 

### Fix
Pin provider-gcp-compute, provider-gcp-container, and provider-gcp-cloudplatform to the v1 channel - restoring the v0.10.0 behaviour.