### PR TITLE
feat: add optional nodes.diskSizeGb (default 20) for the node boot disk

### DIFF
--- a/apis/gke/definition.yaml
+++ b/apis/gke/definition.yaml
@@ -80,6 +80,10 @@ spec:
                           type: string
                           description: instance types associated with the Node Group.
                           default: n1-standard-4
+                        diskSizeGb:
+                          type: integer
+                          description: Boot disk size in GB per node; must be >= the node image size (GKE COS images are ~12GB). Defaults to 20.
+                          default: 20
                       required:
                         - count
                         - instanceType

--- a/examples/gke-xr.yaml
+++ b/examples/gke-xr.yaml
@@ -12,3 +12,4 @@ spec:
     nodes:
       count: 1
       instanceType: e2-standard-2
+      diskSizeGb: 20

--- a/functions/gke/main.k
+++ b/functions/gke/main.k
@@ -161,7 +161,7 @@ _gke_items = [] if not (_service_account_email and _isServiceAccountReady) else 
                 }
                 maxPodsPerNode = 55
                 nodeConfig = {
-                    diskSizeGb = 10
+                    diskSizeGb = params.nodes?.diskSizeGb or 20
                     imageType = "COS_CONTAINERD"
                     machineType = params.nodes.instanceType
                     metadata = {

--- a/tests/test-gke/main.k
+++ b/tests/test-gke/main.k
@@ -182,7 +182,7 @@ _items = [
                             }
                             maxPodsPerNode = 55
                             nodeConfig = {
-                                diskSizeGb = 10
+                                diskSizeGb = 20
                                 imageType = "COS_CONTAINERD"
                                 machineType = "e2-standard-2"
                                 metadata = {


### PR DESCRIPTION
### Description of your changes

Adds an optional nodes.diskSizeGb param (default 20) and wires it to the worker NodePool's boot disk (was hardcoded 10 GB) because GKE 1.34's COS node image is ~12 GB, so a 10 GB boot disk fails node creation.